### PR TITLE
Fatura expira quando vence

### DIFF
--- a/src/Gateways/IuguGateway.php
+++ b/src/Gateways/IuguGateway.php
@@ -56,6 +56,7 @@ class IuguGateway implements Gateway
         $iuguInvoiceData['customer_id'] = $invoice->customer->id;
         $iuguInvoiceData['payer']['cpf_cnpj'] = $invoice->customer->taxDocument;
         $iuguInvoiceData['email'] = $invoice->customer->email;
+        $iuguInvoiceData['expires_in'] = 0;
 
         $iuguInvoiceData['items'] = [];
         foreach ($invoice->items as $item) {


### PR DESCRIPTION
Já existe o campo `expiresAt`que corresponde a data de vencimento da fatura. 
Agora essa data de vencimento será a mesma de expiração.