### PR TITLE
Adiciona método para pagar fatura existente com cartão de crédito

### DIFF
--- a/src/Contracts/Gateway.php
+++ b/src/Contracts/Gateway.php
@@ -66,5 +66,17 @@ interface Gateway
      *
      * @return string
      */
+
+    /**
+     * Charge an invoice with a credit card
+     *
+     * @param  \Potelo\MultiPayment\Models\Invoice  $invoice
+     * @return \Potelo\MultiPayment\Models\Invoice
+     * @throws \Potelo\MultiPayment\Exceptions\ChargingException
+     * @throws \Potelo\MultiPayment\Exceptions\GatewayException
+     * @throws \Potelo\MultiPayment\Exceptions\ModelAttributeValidationException
+     */
+    public function chargeInvoiceWithCreditCard(Invoice $invoice): Invoice;
+
     public function __toString();
 }

--- a/src/Exceptions/MultiPaymentException.php
+++ b/src/Exceptions/MultiPaymentException.php
@@ -2,7 +2,7 @@
 
 namespace Potelo\MultiPayment\Exceptions;
 
-abstract class MultiPaymentException extends \Exception
+class MultiPaymentException extends \Exception
 {
     //
 }

--- a/src/Facades/MultiPayment.php
+++ b/src/Facades/MultiPayment.php
@@ -15,6 +15,7 @@ use Potelo\MultiPayment\Builders\CreditCardBuilder;
  * @method static CustomerBuilder newCustomer()
  * @method static CreditCardBuilder newCreditCard()
  * @method static \Potelo\MultiPayment\MultiPayment setGateway($gateway)
+ * @method static Invoice chargeInvoiceWithCreditCard($invoice, ?string $creditCardToken = null, ?string $creditCardId = null)
  */
 class MultiPayment extends Facade
 {

--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -290,4 +290,23 @@ class Invoice extends Model
         $gateway = ConfigurationHelper::resolveGateway($this->gateway);
         return $gateway->refundInvoice($this);
     }
+
+    /**
+     * Charge invoice with credit card
+     *
+     * @throws \Potelo\MultiPayment\Exceptions\GatewayException
+     * @throws \Potelo\MultiPayment\Exceptions\ModelAttributeValidationException
+     * @throws \Potelo\MultiPayment\Exceptions\ChargingException
+     * @throws \Potelo\MultiPayment\Exceptions\ConfigurationException
+     */
+    public function chargeInvoiceWithCreditCard(?CreditCard $creditCard = null): Invoice
+    {
+        if (!empty($creditCard)) {
+            $this->creditCard = $creditCard;
+        }
+
+        $gateway = ConfigurationHelper::resolveGateway($this->gateway);
+
+        return $gateway->chargeInvoiceWithCreditCard($this);
+    }
 }


### PR DESCRIPTION
O método 'chargeInvoiceWithCreditCard' permite pagar faturas informando o id ou token do cartão de crédito utilizado.